### PR TITLE
Feature: first draft of getworkout endpoint

### DIFF
--- a/backend/core-api/OptiLifts.API/Controllers/WorkoutsController.cs
+++ b/backend/core-api/OptiLifts.API/Controllers/WorkoutsController.cs
@@ -11,19 +11,23 @@ namespace OptiLifts.API.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize]
-public sealed class WorkoutsController : ControllerBase {
+public sealed class WorkoutsController : ControllerBase
+{
     private readonly ISender _sender;
 
-    public WorkoutsController(ISender sender) {
+    public WorkoutsController(ISender sender)
+    {
         _sender = sender;
     }
 
     [HttpGet]
-    public async Task<ActionResult<IReadOnlyList<WorkoutCardDto>>> GetWorkouts(CancellationToken cancellationToken){
+    public async Task<ActionResult<IReadOnlyList<WorkoutCardDto>>> GetWorkouts(CancellationToken cancellationToken)
+    {
         var userIdValue = User.FindFirstValue(JwtRegisteredClaimNames.Sub)
             ?? User.FindFirstValue(ClaimTypes.NameIdentifier);
 
-        if (!Guid.TryParse(userIdValue, out var userId)) {
+        if (!Guid.TryParse(userIdValue, out var userId))
+        {
             return Unauthorized();
         }
 

--- a/backend/core-api/OptiLifts.API/Controllers/WorkoutsController.cs
+++ b/backend/core-api/OptiLifts.API/Controllers/WorkoutsController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MediatR;
+using System.Security.Claims;
+using System.IdentityModel.Tokens.Jwt;
+using OptiLifts.Application.Workouts.GetWorkouts;
+
+namespace OptiLifts.API.Controllers;
+
+//http entrypoint for workout related api calls
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public sealed class WorkoutsController : ControllerBase {
+    private readonly ISender _sender;
+
+    public WorkoutsController(ISender sender) {
+        _sender = sender;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<WorkoutCardDto>>> GetWorkouts(CancellationToken cancellationToken){
+        var userIdValue = User.FindFirstValue(JwtRegisteredClaimNames.Sub)
+            ?? User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (!Guid.TryParse(userIdValue, out var userId)) {
+            return Unauthorized();
+        }
+
+        var result = await _sender.Send(new GetWorkoutsQuery(userId), cancellationToken);
+        return Ok(result);
+    }
+}

--- a/backend/core-api/OptiLifts.API/Program.cs
+++ b/backend/core-api/OptiLifts.API/Program.cs
@@ -29,7 +29,8 @@ builder.Services.AddDbContext<OptiLiftsDbContext>(options =>
     options.UseNpgsql(connectionString));
 
 //register MediatR handlers from Application assembly
-builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(typeof(IAssemblyMarker).Assembly));
+//register MediatR handlers from Application and Infrastructure assemblies
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(typeof(IAssemblyMarker).Assembly, typeof(OptiLiftsDbContext).Assembly));
 
 //register auth implementations
 builder.Services.AddScoped<IPasswordHasher, BcryptPasswordHasher>();
@@ -53,6 +54,7 @@ builder.Services.AddSingleton<IJwtTokenService>(_ => new JwtTokenService(jwtSecr
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
+        options.MapInboundClaims = false;
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = false,

--- a/backend/core-api/OptiLifts.Application/OptiLifts.Application.csproj
+++ b/backend/core-api/OptiLifts.Application/OptiLifts.Application.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="MediatR" Version="14.1.0" />
   </ItemGroup>
 

--- a/backend/core-api/OptiLifts.Application/Workouts/GetWorkouts/GetWorkoutsQuery.cs
+++ b/backend/core-api/OptiLifts.Application/Workouts/GetWorkouts/GetWorkoutsQuery.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace OptiLifts.Application.Workouts.GetWorkouts;
+
+//the request model (ie data needed to run query)
+public sealed record GetWorkoutsQuery(Guid UserId) : IRequest<IReadOnlyList<WorkoutCardDto>>;
+
+//future additions: filter and sorting

--- a/backend/core-api/OptiLifts.Application/Workouts/GetWorkouts/WorkoutCardDto.cs
+++ b/backend/core-api/OptiLifts.Application/Workouts/GetWorkouts/WorkoutCardDto.cs
@@ -1,0 +1,11 @@
+namespace OptiLifts.Application.Workouts.GetWorkouts;
+
+//return shape sent to client
+public sealed record WorkoutCardDto(
+    Guid Id,
+    string Name,
+    string[] PrimaryMuscleGroups,
+    int ExerciseCount,
+    string[] ExercisePreview,
+    DateTime CreatedAt
+);

--- a/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
+++ b/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
@@ -9,7 +9,8 @@ public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IRead
 {
     private readonly OptiLiftsDbContext _dbContext;
 
-    public GetWorkoutsHandler(OptiLiftsDbContext dbContext) {
+    public GetWorkoutsHandler(OptiLiftsDbContext dbContext)
+    {
         _dbContext = dbContext;
     }
 
@@ -19,7 +20,8 @@ public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IRead
             .AsNoTracking()
             .Where(workout => workout.CreatedBy == request.UserId)
             .OrderByDescending(workout => workout.CreatedAt)
-            .Select(workout => new {
+            .Select(workout => new
+            {
                 workout.Id,
                 workout.Name,
                 workout.CreatedAt
@@ -37,7 +39,8 @@ public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IRead
                 from set in _dbContext.Sets.AsNoTracking()
                 join exercise in _dbContext.Exercises.AsNoTracking() on set.ExerciseId equals exercise.Id
                 where workoutIds.Contains(set.WorkoutId)
-                select new {
+                select new
+                {
                     set.WorkoutId,
                     set.OrderIndex,
                     exercise.Id,

--- a/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
+++ b/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
@@ -1,0 +1,78 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using OptiLifts.Application.Workouts.GetWorkouts;
+using OptiLifts.Infrastructure.Database;
+
+namespace OptiLifts.Infrastructure.Workouts;
+
+public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IReadOnlyList<WorkoutCardDto>>
+{
+    private readonly OptiLiftsDbContext _dbContext;
+
+    public GetWorkoutsHandler(OptiLiftsDbContext dbContext) {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<WorkoutCardDto>> Handle(GetWorkoutsQuery request, CancellationToken cancellationToken)
+    {
+        var workouts = await _dbContext.Workouts
+            .AsNoTracking()
+            .Where(workout => workout.CreatedBy == request.UserId)
+            .OrderByDescending(workout => workout.CreatedAt)
+            .Select(workout => new {
+                workout.Id,
+                workout.Name,
+                workout.CreatedAt
+            })
+            .ToListAsync(cancellationToken);
+
+        if (workouts.Count == 0)
+        {
+            return Array.Empty<WorkoutCardDto>();
+        }
+
+        var workoutIds = workouts.Select(workout => workout.Id).ToArray();
+
+        var workoutExercises = await (
+                from set in _dbContext.Sets.AsNoTracking()
+                join exercise in _dbContext.Exercises.AsNoTracking() on set.ExerciseId equals exercise.Id
+                where workoutIds.Contains(set.WorkoutId)
+                select new {
+                    set.WorkoutId,
+                    set.OrderIndex,
+                    exercise.Id,
+                    ExerciseName = exercise.Name,
+                    exercise.PrimaryMuscles
+                })
+            .ToListAsync(cancellationToken);
+
+        return workouts.Select(workout =>
+        {
+            var entries = workoutExercises
+                .Where(entry => entry.WorkoutId == workout.Id)
+                .OrderBy(entry => entry.OrderIndex)
+                .ToList();
+            var exerciseCount = entries
+                .Select(entry => entry.Id)
+                .Distinct()
+                .Count();
+            var exercisePreview = entries
+                .Select(entry => entry.ExerciseName)
+                .Distinct()
+                .Take(3)
+                .ToArray();
+            var primaryMuscleGroups = entries
+                .SelectMany(entry => entry.PrimaryMuscles)
+                .Distinct()
+                .ToArray();
+
+            return new WorkoutCardDto(
+                workout.Id,
+                workout.Name,
+                primaryMuscleGroups,
+                exerciseCount,
+                exercisePreview,
+                workout.CreatedAt);
+        }).ToList();
+    }
+}


### PR DESCRIPTION
# PR Summary — GET /api/workouts

- **Purpose:** Returns the authenticated user's workouts for the My Workouts page.
- **Route:** `GET /api/workouts` (requires `Authorization: Bearer <JWT>`; `sub` claim used as user id).
- **Response:** Array of `WorkoutCardDto` with fields: `id`, `name`, `primaryMuscleGroups`, `exerciseCount`, `exercisePreview`, `createdAt`.
- **Implementation:** Thin API controller → MediatR `GetWorkoutsQuery` → handler (in Infrastructure) that reads from `OptiLiftsDbContext` and composes the DTOs.
- **Local testing:** Start DB and apply schema: `pnpm db && pnpm db:sync` → start backend: `pnpm dev:backend` → seed SQL: `pnpm db:seed:sql`. Call the endpoint with a valid Bearer token.
- **Notes:** Controller accepts `sub` (or mapped `NameIdentifier`) claim; documentation updated in `docs/endpoints/get-workouts.md`.
