### PR TITLE
Fix: Get workout endpoint after db update

### DIFF
--- a/backend/core-api/OptiLifts.Domain/Users/User.cs
+++ b/backend/core-api/OptiLifts.Domain/Users/User.cs
@@ -21,7 +21,7 @@ public class User
     [Encrypted]
     public string? Height { get; set; }
     [Encrypted]
-    public string? Sex { get; set; } 
+    public string? Sex { get; set; }
     //a string converted on the API layer e.g 
     //public enum Sex { Male, Female, Other, PreferNotToSay }
     [Encrypted]

--- a/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
+++ b/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
@@ -36,38 +36,58 @@ public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IRead
         var workoutIds = workouts.Select(workout => workout.Id).ToArray();
 
         var workoutExercises = await (
-                from set in _dbContext.Sets.AsNoTracking()
-                join exercise in _dbContext.Exercises.AsNoTracking() on set.ExerciseId equals exercise.Id
-                where workoutIds.Contains(set.WorkoutId)
-                select new
-                {
-                    set.WorkoutId,
-                    set.OrderIndex,
-                    exercise.Id,
-                    ExerciseName = exercise.Name,
-                    exercise.PrimaryMuscles
-                })
+            from workoutExercise in _dbContext.WorkoutExercises.AsNoTracking()
+            where workoutIds.Contains(workoutExercise.WorkoutId)
+            join exercise in _dbContext.Exercises.AsNoTracking() 
+                on workoutExercise.ExerciseId equals exercise.Id
+            select new
+            {
+                workoutExercise.WorkoutId,
+                workoutExercise.OrderIndex,
+                exercise.Id,
+                ExerciseName = exercise.Name,
+                exercise.PrimaryMuscleId
+            })
             .ToListAsync(cancellationToken);
 
-        return workouts.Select(workout =>
-        {
-            var entries = workoutExercises
-                .Where(entry => entry.WorkoutId == workout.Id)
-                .OrderBy(entry => entry.OrderIndex)
-                .ToList();
-            var exerciseCount = entries
-                .Select(entry => entry.Id)
+            var allPrimaryMuscleIds = workoutExercises
+                .Select(e => e.PrimaryMuscleId)
+                .Where(id => id != Guid.Empty)
                 .Distinct()
-                .Count();
-            var exercisePreview = entries
-                .Select(entry => entry.ExerciseName)
-                .Distinct()
-                .Take(3)
                 .ToArray();
+
+            var muscleMap = new Dictionary<Guid, string>();
+            if (allPrimaryMuscleIds.Length > 0)
+            {
+                muscleMap = await _dbContext.Muscles
+                    .AsNoTracking()
+                    .Where(m => allPrimaryMuscleIds.Contains(m.Id))
+                    .ToDictionaryAsync(m => m.Id, m => m.Name, cancellationToken);
+            }
+
+            return workouts.Select(workout =>
+            {
+                var entries = workoutExercises
+                    .Where(entry => entry.WorkoutId == workout.Id)
+                    .OrderBy(entry => entry.OrderIndex)
+                    .ToList();
+
+                var exerciseCount = entries
+                    .Select(entry => entry.Id)
+                    .Distinct()
+                    .Count();
+                var exercisePreview = entries
+                    .Select(entry => entry.ExerciseName)
+                    .Distinct()
+                    .Take(3)
+                    .ToArray();
+
             var primaryMuscleGroups = entries
-                .SelectMany(entry => entry.PrimaryMuscles)
+                .Select(entry => entry.PrimaryMuscleId)
                 .Distinct()
                 .Take(3)
+                .Select(id => muscleMap.TryGetValue(id, out var name) ? name : null)
+                .Where(name => !string.IsNullOrEmpty(name))
                 .ToArray();
 
             return new WorkoutCardDto(
@@ -77,6 +97,7 @@ public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IRead
                 exerciseCount,
                 exercisePreview,
                 workout.CreatedAt);
-        }).ToList();
+            }).ToList();
+        
     }
 }

--- a/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
+++ b/backend/core-api/OptiLifts.Infrastructure/Workouts/GetWorkoutsHandler.cs
@@ -38,7 +38,7 @@ public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IRead
         var workoutExercises = await (
             from workoutExercise in _dbContext.WorkoutExercises.AsNoTracking()
             where workoutIds.Contains(workoutExercise.WorkoutId)
-            join exercise in _dbContext.Exercises.AsNoTracking() 
+            join exercise in _dbContext.Exercises.AsNoTracking()
                 on workoutExercise.ExerciseId equals exercise.Id
             select new
             {
@@ -50,54 +50,54 @@ public sealed class GetWorkoutsHandler : IRequestHandler<GetWorkoutsQuery, IRead
             })
             .ToListAsync(cancellationToken);
 
-            var allPrimaryMuscleIds = workoutExercises
-                .Select(e => e.PrimaryMuscleId)
-                .Where(id => id != Guid.Empty)
+        var allPrimaryMuscleIds = workoutExercises
+            .Select(e => e.PrimaryMuscleId)
+            .Where(id => id != Guid.Empty)
+            .Distinct()
+            .ToArray();
+
+        var muscleMap = new Dictionary<Guid, string>();
+        if (allPrimaryMuscleIds.Length > 0)
+        {
+            muscleMap = await _dbContext.Muscles
+                .AsNoTracking()
+                .Where(m => allPrimaryMuscleIds.Contains(m.Id))
+                .ToDictionaryAsync(m => m.Id, m => m.Name, cancellationToken);
+        }
+
+        return workouts.Select(workout =>
+        {
+            var entries = workoutExercises
+                .Where(entry => entry.WorkoutId == workout.Id)
+                .OrderBy(entry => entry.OrderIndex)
+                .ToList();
+
+            var exerciseCount = entries
+                .Select(entry => entry.Id)
                 .Distinct()
-                .ToArray();
-
-            var muscleMap = new Dictionary<Guid, string>();
-            if (allPrimaryMuscleIds.Length > 0)
-            {
-                muscleMap = await _dbContext.Muscles
-                    .AsNoTracking()
-                    .Where(m => allPrimaryMuscleIds.Contains(m.Id))
-                    .ToDictionaryAsync(m => m.Id, m => m.Name, cancellationToken);
-            }
-
-            return workouts.Select(workout =>
-            {
-                var entries = workoutExercises
-                    .Where(entry => entry.WorkoutId == workout.Id)
-                    .OrderBy(entry => entry.OrderIndex)
-                    .ToList();
-
-                var exerciseCount = entries
-                    .Select(entry => entry.Id)
-                    .Distinct()
-                    .Count();
-                var exercisePreview = entries
-                    .Select(entry => entry.ExerciseName)
-                    .Distinct()
-                    .Take(3)
-                    .ToArray();
-
-            var primaryMuscleGroups = entries
-                .Select(entry => entry.PrimaryMuscleId)
+                .Count();
+            var exercisePreview = entries
+                .Select(entry => entry.ExerciseName)
                 .Distinct()
                 .Take(3)
-                .Select(id => muscleMap.TryGetValue(id, out var name) ? name : null)
-                .Where(name => !string.IsNullOrEmpty(name))
                 .ToArray();
 
+            var primaryMuscleGroups = entries
+                    .Select(entry => entry.PrimaryMuscleId)
+                    .Distinct()
+                    .Take(3)
+                    .Select(id => muscleMap.TryGetValue(id, out var name) ? name : null)
+                    .Where(name => !string.IsNullOrEmpty(name))
+                    .ToArray();
+
             return new WorkoutCardDto(
-                workout.Id,
-                workout.Name,
-                primaryMuscleGroups,
-                exerciseCount,
-                exercisePreview,
-                workout.CreatedAt);
-            }).ToList();
-        
+                    workout.Id,
+                    workout.Name,
+                    primaryMuscleGroups,
+                    exerciseCount,
+                    exercisePreview,
+                    workout.CreatedAt);
+        }).ToList();
+
     }
 }

--- a/backend/core-api/OptiLifts.Tests/integration/GetWorkoutsEndpointIntegrationTests.cs
+++ b/backend/core-api/OptiLifts.Tests/integration/GetWorkoutsEndpointIntegrationTests.cs
@@ -214,14 +214,23 @@ public sealed class GetWorkoutsApiFixture : IAsyncLifetime
                 SecondaryMuscles = new List<string>()
             };
             db.Exercises.Add(exercise);
-            db.Sets.Add(new WorkoutSet
+
+            var workoutExercise = new WorkoutExercise
             {
                 WorkoutId = workout.Id,
                 ExerciseId = exercise.Id,
+                OrderIndex = index
+            };
+            db.WorkoutExercises.Add(workoutExercise);
+            await db.SaveChangesAsync();
+
+            db.Sets.Add(new WorkoutSet
+            {
+                WorkoutExerciseId = workoutExercise.Id,
                 Type = SetType.Normal,
                 Reps = 8,
                 Weight = 100,
-                OrderIndex = index,
+                OrderIndex = 1,
                 RestTime = 90
             });
         }

--- a/backend/core-api/OptiLifts.Tests/unit/Api.Tests/GetWorkoutsHandlerTests.cs
+++ b/backend/core-api/OptiLifts.Tests/unit/Api.Tests/GetWorkoutsHandlerTests.cs
@@ -77,11 +77,19 @@ public class GetWorkoutsHandlerTests
             CreatedBy = userId,
             FolderId = folder.Id
         };
+        var chest = new Muscle
+        {
+            Name = "Chest"
+        };
+        db.Muscles.Add(chest);
+        await db.SaveChangesAsync();
         var exercise = new Exercise
         {
             Name = "Bench",
-            PrimaryMuscles = new List<string> { "Chest" },
-            Category = "Strength"
+            ExerciseType = ExerciseType.WeightReps,
+            PrimaryMuscleId = chest.Id,
+            UserId = null,
+            ImageUrl = null
         };
 
         db.Workouts.Add(workout);
@@ -91,17 +99,24 @@ public class GetWorkoutsHandlerTests
         workout = await db.Workouts.FirstAsync(w => w.CreatedBy == userId && w.Name == "A");
         exercise = await db.Exercises.FirstAsync(e => e.Name == "Bench");
 
-        var set = new WorkoutSet
+        var workoutExercise = new WorkoutExercise
         {
             WorkoutId = workout.Id,
             ExerciseId = exercise.Id,
+            OrderIndex = 0
+        };
+
+        db.WorkoutExercises.Add(workoutExercise);
+        var set = new WorkoutSet
+        {
+            WorkoutExerciseId = workoutExercise.Id,
             OrderIndex = 0,
             Reps = 1,
             Weight = 10,
             RestTime = 60
         };
-
         db.Sets.Add(set);
+
         await db.SaveChangesAsync();
 
         var handler = new GetWorkoutsHandler(db);
@@ -148,6 +163,17 @@ public class GetWorkoutsHandlerTests
         await db.SaveChangesAsync();
 
         folder = await db.Folders.FirstAsync(f => f.UserId == userId && f.Name == "Default");
+        //new db changes require muscles
+        var chest = new Muscle
+        {
+            Name = "Chest"
+        };
+        var legs = new Muscle
+        {
+            Name = "Legs"
+        };
+        db.Muscles.AddRange(chest, legs);
+        await db.SaveChangesAsync();
 
         var workout = new Workout
         {
@@ -159,15 +185,19 @@ public class GetWorkoutsHandlerTests
         var exercise1 = new Exercise
         {
             Name = "Bench",
-            PrimaryMuscles = new List<string> { "Chest" },
-            Category = "Strength"
+            ExerciseType = ExerciseType.WeightReps,
+            PrimaryMuscleId = chest.Id,
+            UserId = null,
+            ImageUrl = null
         };
 
         var exercise2 = new Exercise
         {
             Name = "Squat",
-            PrimaryMuscles = new List<string> { "Legs" },
-            Category = "Strength"
+            ExerciseType = ExerciseType.WeightReps,
+            PrimaryMuscleId = legs.Id,
+            UserId = null,
+            ImageUrl = null
         };
 
         db.Workouts.Add(workout);
@@ -178,10 +208,25 @@ public class GetWorkoutsHandlerTests
         exercise1 = await db.Exercises.FirstAsync(e => e.Name == "Bench");
         exercise2 = await db.Exercises.FirstAsync(e => e.Name == "Squat");
 
-        var set1 = new WorkoutSet
+        //new db changes
+        var workoutExercise1 = new WorkoutExercise
         {
             WorkoutId = workout.Id,
             ExerciseId = exercise1.Id,
+            OrderIndex = 0
+        };
+        var workoutExercise2 = new WorkoutExercise
+        {
+            WorkoutId = workout.Id,
+            ExerciseId = exercise2.Id,
+            OrderIndex = 1
+        };
+        db.WorkoutExercises.AddRange(workoutExercise1, workoutExercise2);
+        await db.SaveChangesAsync();
+
+        var set1 = new WorkoutSet
+        {
+            WorkoutExerciseId = workoutExercise1.Id,
             OrderIndex = 0,
             Reps = 5,
             Weight = 100,
@@ -190,8 +235,7 @@ public class GetWorkoutsHandlerTests
 
         var set2 = new WorkoutSet
         {
-            WorkoutId = workout.Id,
-            ExerciseId = exercise2.Id,
+            WorkoutExerciseId = workoutExercise2.Id,
             OrderIndex = 1,
             Reps = 5,
             Weight = 150,


### PR DESCRIPTION
- Updated the GetWorkouts endpoint with required changes after db finalisation.
- Updated the testing in ```GetWorkoutsHandlerTests.cs```
- Ran the individual tests with 
       ```dotnet test backend/core-api/OptiLifts.Tests --filter FullyQualifiedName~GetWorkoutsHandlerTests```
- Confirmed all 3 tests pass, and frontend implementation still works (ie workouts are fetched correctly for user).